### PR TITLE
Loading histo slices

### DIFF
--- a/histogram/histogram.py
+++ b/histogram/histogram.py
@@ -331,7 +331,7 @@ class Histogram1D:
 
         if isinstance(rows, int):
 
-            rows = (slice(rows, rows+1, 1), )
+            rows = (slice(rows, rows + 1, 1),)
 
         elif isinstance(rows, tuple):
 
@@ -358,7 +358,7 @@ class Histogram1D:
 
                 if rows is not None:
 
-                    rows_table = rows + (slice(0, -1, 1), )
+                    rows_table = rows + (slice(0, -1, 1),)
                     data = f['data'][rows_table]
                     underflow = f['underflow'][rows]
                     overflow = f['overflow'][rows]

--- a/histogram/histogram.py
+++ b/histogram/histogram.py
@@ -356,17 +356,33 @@ class Histogram1D:
 
             with fitsio.FITS(path, mode='r') as f:
 
+                data = f['data']
+                underflow = f['underflow']
+                overflow = f['overflow']
+
                 if rows is not None:
 
-                    rows_table = rows + (slice(0, -1, 1),)
-                    data = f['data'][rows_table]
-                    underflow = f['underflow'][rows]
-                    overflow = f['overflow'][rows]
+                    dims_data = data._info['dims']
+                    dims_flow = overflow._info['dims']
+                    rows_data = rows
+
+                    for _ in range(len(dims_data) - len(rows)):
+
+                        rows_data += (slice(0, -1, 1),)
+
+                    for _ in range(len(dims_flow) - len(rows)):
+
+                        rows += (slice(0, -1, 1),)
+
+                    data = data[rows_data]
+                    underflow = underflow[rows]
+                    overflow = overflow[rows]
+
                 else:
 
-                    data = f['data'].read()
-                    underflow = f['underflow'].read()
-                    overflow = f['overflow'].read()
+                    data = data.read()
+                    underflow = underflow.read()
+                    overflow = overflow.read()
 
                 bins = f['bins'].read()
                 data = np.squeeze(data)

--- a/histogram/histogram.py
+++ b/histogram/histogram.py
@@ -325,9 +325,26 @@ class Histogram1D:
                 extension))
 
     @classmethod
-    def load(cls, path):
+    def load(cls, path, rows=None):
 
         _, extension = os.path.splitext(path)
+
+        if isinstance(rows, int):
+
+            rows = (slice(rows, rows+1, 1), )
+
+        elif isinstance(rows, tuple):
+
+            new_rows = ()
+            for i in rows:
+
+                new_rows += (slice(i, i + 1, 1), )
+
+            rows = new_rows
+
+        elif rows is not None:
+
+            raise ValueError('Unsupported value for row : {}'.format(rows))
 
         if extension == '.pk':
 
@@ -339,10 +356,23 @@ class Histogram1D:
 
             with fitsio.FITS(path, mode='r') as f:
 
-                data = f['data'].read()
+                if rows is not None:
+
+                    rows_table = rows + (slice(0, -1, 1), )
+                    data = f['data'][rows_table]
+                    underflow = f['underflow'][rows]
+                    overflow = f['overflow'][rows]
+                else:
+
+                    data = f['data'].read()
+                    underflow = f['underflow'].read()
+                    overflow = f['overflow'].read()
+
                 bins = f['bins'].read()
-                underflow = f['underflow'].read()
-                overflow = f['overflow'].read()
+                data = np.squeeze(data)
+                bins = np.squeeze(bins)
+                underflow = np.squeeze(underflow)
+                overflow = np.squeeze(overflow)
 
             obj = Histogram1D(bin_edges=bins, data_shape=data.shape[:-1])
             obj.data = data

--- a/histogram/tests/test_histogram1d.py
+++ b/histogram/tests/test_histogram1d.py
@@ -132,7 +132,7 @@ def test_load_slice():
             loaded_histo = Histogram1D.load(f.name, rows=0)
             assert histo[0] == loaded_histo
             assert histo[1] != loaded_histo
-            loaded_histo = Histogram1D.load(f.name, rows=(0, ))
+            loaded_histo = Histogram1D.load(f.name, rows=(0,))
             assert histo[0] == loaded_histo
             assert histo[1] != loaded_histo
 
@@ -140,7 +140,7 @@ def test_load_slice():
             assert histo[1] == loaded_histo
             assert histo[0] != loaded_histo
 
-            loaded_histo = Histogram1D.load(f.name, rows=(1, ))
+            loaded_histo = Histogram1D.load(f.name, rows=(1,))
             assert histo[1] == loaded_histo
             assert histo[0] != loaded_histo
 

--- a/histogram/tests/test_histogram1d.py
+++ b/histogram/tests/test_histogram1d.py
@@ -2,7 +2,6 @@ from histogram.histogram import Histogram1D
 import numpy as np
 from copy import copy
 import tempfile
-import os
 import pytest
 
 
@@ -10,7 +9,19 @@ def _make_dummy_histo():
 
     bin_edges = np.arange(1000)
     n_histo = 2
-    data_shape = (n_histo,)
+    data_shape = (n_histo, )
+    histo = Histogram1D(bin_edges=bin_edges, data_shape=data_shape)
+
+    assert histo.shape == data_shape + (len(bin_edges) - 1, )
+
+    return histo
+
+
+def _make_dummy_2D_1dhisto():
+
+    bin_edges = np.arange(1000)
+    n_histo = 2
+    data_shape = (n_histo, n_histo)
     histo = Histogram1D(bin_edges=bin_edges, data_shape=data_shape)
 
     assert histo.shape == data_shape + (len(bin_edges) - 1, )
@@ -92,6 +103,66 @@ def test_save_and_load():
             loaded_histo = Histogram1D.load(f.name)
 
             assert histo == loaded_histo
+
+
+def test_save_and_load_2D_1dhisto():
+
+    histo = _make_dummy_2D_1dhisto()
+
+    for ext in ['.pk', '.fits']:
+
+        with tempfile.NamedTemporaryFile(suffix=ext) as f:
+
+            histo.save(f.name)
+            loaded_histo = Histogram1D.load(f.name)
+
+            assert histo == loaded_histo
+
+
+def test_load_slice():
+
+    histo = _make_dummy_histo()
+    histo[0].data += 1
+
+    for ext in ['.fits']:
+
+        with tempfile.NamedTemporaryFile(suffix=ext) as f:
+
+            histo.save(f.name)
+            loaded_histo = Histogram1D.load(f.name, rows=0)
+            assert histo[0] == loaded_histo
+            assert histo[1] != loaded_histo
+            loaded_histo = Histogram1D.load(f.name, rows=(0, ))
+            assert histo[0] == loaded_histo
+            assert histo[1] != loaded_histo
+
+            loaded_histo = Histogram1D.load(f.name, rows=1)
+            assert histo[1] == loaded_histo
+            assert histo[0] != loaded_histo
+
+            loaded_histo = Histogram1D.load(f.name, rows=(1, ))
+            assert histo[1] == loaded_histo
+            assert histo[0] != loaded_histo
+
+
+def test_load_slice_2D_1dhisto():
+
+    histo = _make_dummy_2D_1dhisto()
+    histo[0, 0].data += 1
+    histo[1, 1].data += 2
+
+    for ext in ['.fits']:
+
+        with tempfile.NamedTemporaryFile(suffix=ext) as f:
+
+            histo.save(f.name)
+            loaded_histo = Histogram1D.load(f.name, rows=(0, 0))
+            assert histo[0, 0] == loaded_histo
+            assert histo[1, 1] != loaded_histo
+
+            loaded_histo = Histogram1D.load(f.name, rows=(1, 1))
+            assert histo[1, 1] == loaded_histo
+            assert histo[0, 1] != loaded_histo
 
 
 @pytest.mark.xfail
@@ -206,3 +277,4 @@ if __name__ == '__main__':
 
     test_fill()
     test_fill_indices()
+    test_load_slice()

--- a/histogram/tests/test_histogram1d.py
+++ b/histogram/tests/test_histogram1d.py
@@ -164,6 +164,16 @@ def test_load_slice_2D_1dhisto():
             assert histo[1, 1] == loaded_histo
             assert histo[0, 1] != loaded_histo
 
+            loaded_histo = Histogram1D.load(f.name, rows=(1, ))
+
+            assert histo[1] == loaded_histo
+            assert histo[0] != loaded_histo
+
+            loaded_histo = Histogram1D.load(f.name, rows=(0,))
+
+            assert histo[0] == loaded_histo
+            assert histo[1] != loaded_histo
+
 
 @pytest.mark.xfail
 def test_save_not_defined_format():

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open(REQUIREMENT_FILE) as f:
 requires = [x.strip() for x in content]
 setup(
     name='histogram',
-    version='0.5.0',
+    version='0.6.0',
     packages=['histogram'],
     url='https://github.com/cta-sst-1m/histogram',
     license='GNU GPL 3.0',


### PR DESCRIPTION
This PR includes the feature to load a slice of histograms from disk to memory. Avoiving to have to put a for instance (100, 100, 1296, n_bins) array into memory.

The user can do : 
```python
from histogram.histogram import Histogram1D

histo = Histogram1D.load('my_large_histo.fits', rows=(1,20, 3))

hist = Histogram1D.load('my_large_histo.fits', rows=(1, ))

```